### PR TITLE
Added functions to turn on and turn off the display

### DIFF
--- a/src/display.rs
+++ b/src/display.rs
@@ -350,6 +350,17 @@ where
     pub fn rotation(&self) -> DisplayRotation {
         self.display_rotation
     }
+
+    /// Turn the display off (eg exiting sleep mode)
+    pub fn turn_on(&mut self) -> Result<(), Error<CommE, PinE>> {
+        Command::DisplayOn(true).send(&mut self.spi, &mut self.dc)
+    }
+
+    /// Turn the display off (sleep mode)
+    pub fn turn_off(&mut self) -> Result<(), Error<CommE, PinE>> {
+        Command::DisplayOn(false).send(&mut self.spi, &mut self.dc)
+    }
+
 }
 
 #[cfg(feature = "graphics")]

--- a/src/display.rs
+++ b/src/display.rs
@@ -351,16 +351,15 @@ where
         self.display_rotation
     }
 
-    /// Turn the display off (eg exiting sleep mode)
+    /// Turn the display on (eg exiting sleep mode)
     pub fn turn_on(&mut self) -> Result<(), Error<CommE, PinE>> {
         Command::DisplayOn(true).send(&mut self.spi, &mut self.dc)
     }
 
-    /// Turn the display off (sleep mode)
+    /// Turn the display off (enter sleep mode)
     pub fn turn_off(&mut self) -> Result<(), Error<CommE, PinE>> {
         Command::DisplayOn(false).send(&mut self.spi, &mut self.dc)
     }
-
 }
 
 #[cfg(feature = "graphics")]


### PR DESCRIPTION
This is useful for battery-powered applications etc, where you regularly turn off and on the display. (The datasheet also calls this "sleep mode", which is appropriate here.